### PR TITLE
DEVS-2613: Machine runner3 support

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.2
+version: 0.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.1
+version: 0.1.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -68,7 +68,7 @@ spec:
               command:
                 - /bin/sh
                 - -c
-                - ps -ef | grep circleci-launch-agent
+                - ps -ef | grep circleci-launch-agent | grep -v grep
             initialDelaySeconds: 3
             periodSeconds: 5
           resources:

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -43,6 +43,15 @@ spec:
                 secretKeyRef:
                   key: runnerToken
                   name: {{ .Values.configSecret.name }}
+            - name: "CIRCLECI_RUNNER_API_AUTH_TOKEN"
+              valueFrom:
+                secretKeyRef:
+                  key: runnerToken
+                  name: {{ .Values.configSecret.name }}
+            - name: "CIRCLECI_RUNNER_NAME"
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
             {{- range .Values.env }}
             - name: {{ .name }}
               {{- if .value }}
@@ -59,7 +68,7 @@ spec:
               command:
                 - /bin/sh
                 - -c
-                - ps -ef | grep circleci-launch-agent
+                - ps -ef | grep circleci-runner
             initialDelaySeconds: 3
             periodSeconds: 5
           resources:

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -68,7 +68,7 @@ spec:
               command:
                 - /bin/sh
                 - -c
-                - ps -ef | grep circleci-launch-agent | grep -v grep
+                - ps -ef | grep circleci-launch-agent
             initialDelaySeconds: 3
             periodSeconds: 5
           resources:

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -68,7 +68,7 @@ spec:
               command:
                 - /bin/sh
                 - -c
-                - ps -ef | grep circleci-runner
+                - ps -ef | grep circleci-launch-agent
             initialDelaySeconds: 3
             periodSeconds: 5
           resources:


### PR DESCRIPTION
This helm chart is now a deprecated way to use K8s self hosted runners. This means the existing helm chart supports only launch-agent and not machine runner 3.0. 

Hence the repo is forked under eventbrite and the following changes are made to make it compatible to machine runner 3.0
- Setup CircleCI API token compatible with machine runner 3.0
- Add required field runner name and set value to hostname
- Incremented chart version